### PR TITLE
Fix CUDA seeding in on-policy training

### DIFF
--- a/on_policy_train.py
+++ b/on_policy_train.py
@@ -27,7 +27,7 @@ def set_seed(seed: int):
     random.seed(seed)
     torch.manual_seed(seed)
     if torch.cuda.is_available():
-        torch.cuda.manual_seed_a
+        torch.cuda.manual_seed_all(seed)
 
 def load_config(config_file):
     with open(config_file, 'r') as f:


### PR DESCRIPTION
## Summary
- ensure CUDA RNG is seeded correctly in `on_policy_train.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a310ae18c8330933097a9af58fbed