### PR TITLE
Add parallel evolution with MLP models

### DIFF
--- a/population_utils.py
+++ b/population_utils.py
@@ -2,13 +2,16 @@
 #!/usr/bin/env python3
 
 import yaml
-import torch
 import random
 import torch
+import torch.nn as nn
+import torch.nn.functional as F
 
 from tqdm import trange
 
+from curriculum import get_mixed_loader
 from curriculum_env import CurriculumEnv
+from utils import _get_bin_edges, _MAX_LOSS
 
 def set_seed(seed: int):
     random.seed(seed)
@@ -123,6 +126,242 @@ def evaluate_candidate(env: CurriculumEnv,
             break
 
     return transitions, total_reward
+
+
+class PaddedBatchedMLP(nn.Module):
+    """Minimal padded MLP supporting a batch of differently-sized networks."""
+
+    def __init__(self, configs, init_models=None, input_dim=28*28, output_dim=10):
+        super().__init__()
+        self.configs = configs
+        self.num_models = len(configs)
+        self.depths = [len(c) for c in configs]
+        self.max_depth = max(self.depths)
+        self.max_width = max(max(c) for c in configs)
+
+        dims = [input_dim] + [self.max_width]*self.max_depth + [output_dim]
+        self.weights = nn.ParameterList([
+            nn.Parameter(torch.zeros(self.num_models, dims[i+1], dims[i]))
+            for i in range(len(dims)-1)
+        ])
+        self.biases = nn.ParameterList([
+            nn.Parameter(torch.zeros(self.num_models, dims[i+1]))
+            for i in range(len(dims)-1)
+        ])
+
+        # either copy from provided models or random init
+        if init_models:
+            for mi, model in enumerate(init_models):
+                li = 0
+                for m in model:
+                    if isinstance(m, nn.Linear):
+                        out, inp = m.weight.size()
+                        self.weights[li].data[mi, :out, :inp].copy_(m.weight.data)
+                        self.biases[li].data[mi, :out].copy_(m.bias.data)
+                        li += 1
+        else:
+            for mi, cfg in enumerate(configs):
+                full = [input_dim] + cfg + [output_dim]
+                for li in range(len(full)-1):
+                    out, inp = full[li+1], full[li]
+                    self.weights[li].data[mi, :out, :inp].normal_(0.0, 0.1)
+                    self.biases[li].data[mi, :out].normal_(0.0, 0.1)
+
+        for li in range(self.max_depth):
+            mask = torch.tensor([li < d for d in self.depths], dtype=torch.bool)
+            self.register_buffer(f"mask_{li}", mask.view(-1,1,1))
+
+    def forward(self, x):
+        x = x.view(x.size(0), -1)
+        x = x.unsqueeze(0).expand(self.num_models, -1, -1)
+        for li, (W, B) in enumerate(zip(self.weights, self.biases)):
+            y = torch.bmm(W.to(x.device), x.transpose(1,2)).transpose(1,2) + B.to(x.device).unsqueeze(1)
+            if li == self.max_depth:
+                x = y
+            else:
+                if li == 0:
+                    x = F.relu(y)
+                else:
+                    mask = getattr(self, f"mask_{li}")
+                    x = torch.where(mask, F.relu(y), x)
+        return x
+
+
+def _run_phase_training_batched(model, easy_loader, medium_loader, hard_loader, hp, device):
+    """Train a PaddedBatchedMLP for one phase and return per-model rewards."""
+    phase_batch_size = hp.get("phase_batch_size", 1024)
+    criterion = nn.CrossEntropyLoss(reduction="none")
+
+    mixed = get_mixed_loader(
+        easy_loader.dataset,
+        medium_loader.dataset,
+        hard_loader.dataset,
+        hp["mixture_ratio"],
+        num_samples=hp["training_samples"],
+        batch_size=phase_batch_size,
+    )
+
+    opt = torch.optim.Adam(model.parameters(), lr=hp["learning_rate"])
+    model.train()
+    phase_samples = 0
+    for imgs, labels in mixed:
+        imgs, labels = imgs.to(device), labels.to(device)
+        opt.zero_grad()
+        outs = model(imgs)
+        lbl = labels.expand(model.num_models, -1)
+        losses = criterion(outs.view(-1, outs.size(-1)), lbl.reshape(-1))
+        loss_pm = losses.view(model.num_models, -1).mean(dim=1)
+        loss_pm.sum().backward()
+        opt.step()
+        phase_samples += imgs.size(0)
+        if phase_samples >= hp["training_samples"]:
+            break
+
+    def acc(loader):
+        correct = torch.zeros(model.num_models, device=device)
+        total = 0
+        with torch.no_grad():
+            for xb, yb in loader:
+                xb = xb.to(device)
+                yb = yb.to(device)
+                preds = model(xb).argmax(dim=2)
+                correct += (preds == yb).sum(dim=1).to(correct.dtype)
+                total += yb.size(0)
+        return correct / total * 100.0
+
+    ea = acc(easy_loader)
+    ma = acc(medium_loader)
+    ha = acc(hard_loader)
+    return ((ea + ma + ha) / 3.0).tolist()
+
+
+def eval_loader_batched(model, loader, device, num_bins):
+    """Vectorized eval_loader for PaddedBatchedMLP."""
+    model.eval()
+    device = torch.device(device) if isinstance(device, str) else device
+
+    hist_c = torch.zeros(model.num_models, num_bins, device=device)
+    hist_i = torch.zeros(model.num_models, num_bins, device=device)
+
+    edges = _get_bin_edges(num_bins, device)
+    boundaries = edges[1:-1]
+    ce_loss = nn.CrossEntropyLoss(reduction="none")
+    max_batches = int(len(loader) * 0.5)
+    with torch.no_grad():
+        for bi, (imgs, labels) in enumerate(loader):
+            imgs = imgs.to(device, non_blocking=True)
+            labels = labels.to(device, non_blocking=True)
+            outs = model(imgs)  # [num_models, batch, C]
+            lbl = labels.expand(model.num_models, -1)
+            losses = ce_loss(outs.view(-1, outs.size(-1)), lbl.reshape(-1))
+            losses = losses.view(model.num_models, -1)
+            preds = outs.argmax(dim=2)
+            correct = preds.eq(labels)
+            for mi in range(model.num_models):
+                lc = losses[mi][correct[mi]].clamp(0.0, _MAX_LOSS)
+                li = losses[mi][~correct[mi]].clamp(0.0, _MAX_LOSS)
+                bc = torch.bucketize(lc, boundaries)
+                bi_idx = torch.bucketize(li, boundaries)
+                hist_c[mi] += torch.bincount(bc, minlength=num_bins).float()
+                hist_i[mi] += torch.bincount(bi_idx, minlength=num_bins).float()
+            if bi > max_batches:
+                break
+
+    totals = hist_c + hist_i
+    S = totals.sum(dim=1, keepdim=True)
+    mask = S > 0
+    hist_c[mask] /= S[mask]
+    hist_i[mask] /= S[mask]
+    return hist_c, hist_i
+
+
+def evaluate_candidate_parallel(cfg: dict,
+                                candidate: torch.Tensor,
+                                candidate_dim: int,
+                                num_phases: int,
+                                num_models: int):
+    """Evaluate a candidate using multiple random MLP models in parallel."""
+    base_env = CurriculumEnv(cfg)
+    base_env.reset()
+
+    model_cfgs = []
+    for _ in range(num_models):
+        depth = random.randint(1, 3)
+        widths = [random.randint(32, 128) for _ in range(depth)]
+        model_cfgs.append(widths)
+
+    depth_groups = {}
+    for idx, cfgs in enumerate(model_cfgs):
+        depth_groups.setdefault(len(cfgs), []).append(idx)
+
+    group_models = {
+        d: PaddedBatchedMLP([model_cfgs[i] for i in idxs]).to(base_env.device)
+        for d, idxs in depth_groups.items()
+    }
+
+    def get_obs_group(vec_model):
+        ec, ei = eval_loader_batched(vec_model, base_env.easy_loader, base_env.device, base_env.num_bins)
+        mc, mi = eval_loader_batched(vec_model, base_env.medium_loader, base_env.device, base_env.num_bins)
+        hc, hi = eval_loader_batched(vec_model, base_env.hard_loader, base_env.device, base_env.num_bins)
+        counts = [len(base_env.easy_subset), len(base_env.medium_subset), len(base_env.hard_subset)]
+        total = sum(counts)
+        rel = torch.tensor([c/total for c in counts], device=base_env.device).view(1,-1)
+        rel = rel.expand(vec_model.num_models, -1)
+        obs = torch.cat([ec, ei, mc, mi, hc, hi, rel], dim=1)
+        phase = torch.full((vec_model.num_models,1), base_env.current_phase/base_env.max_phases, device=base_env.device)
+        avail = torch.full((vec_model.num_models,1), base_env.remaining_samples/base_env.train_samples_max, device=base_env.device)
+        return torch.cat([obs, phase, avail], dim=1)
+
+    states = [None for _ in range(num_models)]
+    for d, idxs in depth_groups.items():
+        obs = get_obs_group(group_models[d])
+        for li, gi in enumerate(idxs):
+            states[gi] = obs[li]
+
+    unit = candidate_dim // num_phases
+    remaining = base_env.train_samples_max
+    total_rewards = [0.0 for _ in range(num_models)]
+    transitions = []
+
+    done = False
+    for p in range(num_phases):
+        idx = p * unit
+        action = candidate[idx:idx+unit]
+        lr, mix, frac = float(action[0]), action[1:4], float(action[4])
+        num = int(frac * remaining)
+        hp = {"training_samples": num, "learning_rate": lr,
+              "mixture_ratio": mix.tolist(), "phase_batch_size": base_env.batch_size}
+
+        rewards = [0.0 for _ in range(num_models)]
+        for d, idxs in depth_groups.items():
+            vec = group_models[d]
+            r = _run_phase_training_batched(vec, base_env.easy_loader,
+                                            base_env.medium_loader,
+                                            base_env.hard_loader,
+                                            hp, base_env.device)
+            for li, gi in enumerate(idxs):
+                rewards[gi] = r[li]
+
+        remaining -= num
+        base_env.remaining_samples = remaining
+        base_env.current_phase += 1
+        done = (base_env.current_phase >= base_env.max_phases) or remaining <= 0 or frac <= 0
+
+        next_states = [None for _ in range(num_models)]
+        for d, idxs in depth_groups.items():
+            obs = get_obs_group(group_models[d])
+            for li, gi in enumerate(idxs):
+                next_states[gi] = obs[li]
+
+        for j in range(num_models):
+            transitions.append((states[j], action, rewards[j], next_states[j], done))
+            total_rewards[j] += rewards[j]
+
+        states = next_states
+        if done:
+            break
+
+    return transitions, sum(total_rewards) / num_models
 
 
 

--- a/run_evolution_parallel.sh
+++ b/run_evolution_parallel.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VENV_PATH="../envs/spcl"
+echo "Activating venv at $VENV_PATH"
+# shellcheck source=/dev/null
+source "$VENV_PATH/bin/activate"
+
+CONFIG="config.yaml"
+GPUS=(0 1 2 3 4)
+RUNS_PER_GPU=1
+POP_SIZE=12
+GENERATIONS=2
+NUM_MODELS=4
+
+SAVE_PATH="evo_results_parallel/saved_model_checkpoints"
+POP_DIR="evo_results_parallel/populations"
+EVAL_DIR="evo_results_parallel/eval_parts"
+HIST_DIR="evo_results_parallel/history"
+LOG_DIR="evo_results_parallel/logs"
+PID_FILE="evo_results_parallel/pids.txt"
+
+rm -f "$PID_FILE"
+mkdir -p "$POP_DIR" "$EVAL_DIR" "$HIST_DIR" "$SAVE_PATH" "$LOG_DIR"
+
+python init_population.py --config "$CONFIG" --output "$POP_DIR/pop_gen_0.pt" 2>&1 | tee "$LOG_DIR/init_population.log"
+
+for (( gen=0; gen<GENERATIONS; gen++ )); do
+  echo "=== Generation $gen ===" | tee -a "$LOG_DIR/run_evolution_parallel.log"
+  POP_FILE="$POP_DIR/pop_gen_${gen}.pt"
+
+  TOTAL_RUNS=$(( ${#GPUS[@]} * RUNS_PER_GPU ))
+  BASE=$(( POP_SIZE / TOTAL_RUNS ))
+  REM=$(( POP_SIZE % TOTAL_RUNS ))
+  run_idx=0
+
+  rm -f "$EVAL_DIR"/eval_gen${gen}_part*.pt
+
+  for gpu in "${GPUS[@]}"; do
+    for _ in $(seq 1 $RUNS_PER_GPU); do
+      start=$(( run_idx * BASE ))
+      cnt=$BASE
+      if [ "$run_idx" -lt "$REM" ]; then
+        cnt=$(( cnt + 1 ))
+      fi
+      OUT="$EVAL_DIR/eval_gen${gen}_part${run_idx}.pt"
+      LOGF="$LOG_DIR/eval_gen${gen}_part${run_idx}.log"
+
+      echo "Launching eval gen $gen part $run_idx → GPU $gpu (idx $start cnt $cnt)" | tee -a "$LOG_DIR/run_evolution_parallel.log"
+      CUDA_VISIBLE_DEVICES=$gpu python eval_population.py \
+        --config "$CONFIG" --pop_file "$POP_FILE" \
+        --start_idx "$start" --num_candidates "$cnt" \
+        --out_file "$OUT" --num_models "$NUM_MODELS" --model_type mlp \
+        > "$LOGF" 2>&1 &
+      echo $! >> "$PID_FILE"
+      run_idx=$(( run_idx + 1 ))
+    done
+  done
+
+  echo "Waiting for all $TOTAL_RUNS eval jobs…" | tee -a "$LOG_DIR/run_evolution_parallel.log"
+  wait
+  echo "All evals for gen $gen done." | tee -a "$LOG_DIR/run_evolution_parallel.log"
+
+  python merge_history.py --history_dir "$EVAL_DIR" --output "$HIST_DIR/history_gen${gen}.pt" 2>&1 | tee -a "$LOG_DIR/merge_history_gen${gen}.log"
+
+  NEXT_POP="$POP_DIR/pop_gen_$((gen+1)).pt"
+  python evolve_population.py --config "$CONFIG" --pop_file "$POP_FILE" --eval_dir "$EVAL_DIR" --gen "$gen" --output_population "$NEXT_POP" --history_dir "$HIST_DIR" 2>&1 | tee -a "$LOG_DIR/evolve.log"
+done
+
+FINAL_DS="$SAVE_PATH/evolutionary_dataset.pt"
+python merge_history.py --history_dir "$EVAL_DIR" --output "$FINAL_DS" 2>&1 | tee -a "$LOG_DIR/merge_history.log"
+
+rm -f "$PID_FILE"
+
+echo "✅ Parallel evolution run complete. Logs in $LOG_DIR"


### PR DESCRIPTION
## Summary
- support MLP model type in `CurriculumEnv`
- allow evaluating multiple random models per candidate in `eval_population.py`
- new script `run_evolution_parallel.sh` to run parallel evolution using random MLPs
- implement parallel evaluation in `population_utils` with padded batched MLPs
- refactor parallel evaluation to avoid per-model env loops

## Testing
- `python -m py_compile population_utils.py eval_population.py curriculum_env.py`


------
https://chatgpt.com/codex/tasks/task_e_684764b06a9083309060313c86bb122b