### PR TITLE
Fix reshape issue in eval_loader_batched

### DIFF
--- a/population_utils.py
+++ b/population_utils.py
@@ -253,8 +253,8 @@ def eval_loader_batched(model, loader, device, num_bins):
             labels = labels.to(device, non_blocking=True)
             outs = model(imgs)  # [num_models, batch, C]
             lbl = labels.expand(model.num_models, -1)
-            losses = ce_loss(outs.view(-1, outs.size(-1)), lbl.reshape(-1))
-            losses = losses.view(model.num_models, -1)
+            losses = ce_loss(outs.reshape(-1, outs.size(-1)), lbl.reshape(-1))
+            losses = losses.reshape(model.num_models, -1)
             preds = outs.argmax(dim=2)
             correct = preds.eq(labels)
             for mi in range(model.num_models):


### PR DESCRIPTION
## Summary
- fix non-contiguous tensor handling in `eval_loader_batched`

## Testing
- `python -m py_compile population_utils.py`
- `python -m py_compile eval_population.py`


------
https://chatgpt.com/codex/tasks/task_e_684770deb3288330906f054c18525150