### PR TITLE
Fix missing eval file detection

### DIFF
--- a/run_evolution_parallel.sh
+++ b/run_evolution_parallel.sh
@@ -51,6 +51,7 @@ for (( gen=0; gen<GENERATIONS; gen++ )); do
         --config "$CONFIG" --pop_file "$POP_FILE" \
         --start_idx "$start" --num_candidates "$cnt" \
         --out_file "$OUT" --num_models "$NUM_MODELS" --model_type mlp \
+        --parallel \
         > "$LOGF" 2>&1 &
       echo $! >> "$PID_FILE"
       run_idx=$(( run_idx + 1 ))


### PR DESCRIPTION
## Summary
- use absolute directories for output paths in `run_evolution.sh`
- verify the expected number of evaluation files exist before merging history
- make evaluation script support non-parallel mode for `run_evolution.sh`
- call new parallel flag from `run_evolution_parallel.sh`

## Testing
- `bash -n run_evolution.sh run_evolution_parallel.sh`
- `python -m py_compile eval_population.py`

------
https://chatgpt.com/codex/tasks/task_e_684831ea93ac8330a5642a7933d96dba