### PR TITLE
Fix eval_loader_batched division by totals

### DIFF
--- a/population_utils.py
+++ b/population_utils.py
@@ -274,10 +274,9 @@ def eval_loader_batched(model, loader, device, num_bins):
                 break
 
     totals = hist_c + hist_i
-    S = totals.sum(dim=1, keepdim=True)
-    mask = S.squeeze(-1) > 0
-    hist_c[mask] /= S[mask]
-    hist_i[mask] /= S[mask]
+    S = totals.sum(dim=1, keepdim=True).clamp(min=1.0)
+    hist_c /= S
+    hist_i /= S
     return hist_c, hist_i
 
 


### PR DESCRIPTION
## Summary
- avoid boolean mask indexing that caused `IndexError` during histogram normalization

## Testing
- `python -m py_compile population_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_684832ff87c48330984afa0d96edd895