### PR TITLE
Fix CUDA seed call in on_policy_train

### DIFF
--- a/on_policy_train.py
+++ b/on_policy_train.py
@@ -27,7 +27,7 @@ def set_seed(seed: int):
     random.seed(seed)
     torch.manual_seed(seed)
     if torch.cuda.is_available():
-        torch.cuda.manual_seed_a
+        torch.cuda.manual_seed_all(seed)
 
 def load_config(config_file):
     with open(config_file, 'r') as f:


### PR DESCRIPTION
## Summary
- update `set_seed` in `on_policy_train.py` to call `torch.cuda.manual_seed_all`

## Testing
- `python -m py_compile on_policy_train.py`

------
https://chatgpt.com/codex/tasks/task_e_68483e212bf08330a165587df49d3ea8