### PR TITLE
Fix action creation in on-policy probing

### DIFF
--- a/on_policy_train.py
+++ b/on_policy_train.py
@@ -117,7 +117,7 @@ def main():
         probe_states = []
         state = env.reset()
         for _ in tqdm(range(probe_batch_size), desc="Probing"):
-            action = agent.select_action(state, noise_enable=True), None, None
+            action = agent.select_action(state, noise_enable=True)
             next_state, _, done = env.step(action)
             probe_states.append(state)
             state = env.reset() if done else next_state


### PR DESCRIPTION
## Summary
- ensure `agent.select_action` result is passed directly during probing

## Testing
- `python -m py_compile on_policy_train.py`

------
https://chatgpt.com/codex/tasks/task_e_68483e5cabd88330b94b346c64570379