### PR TITLE
Fix tensor stacking when evaluating BC model

### DIFF
--- a/evaluate_bc_model.py
+++ b/evaluate_bc_model.py
@@ -31,7 +31,7 @@ def rollout_episode(agent, env, gamma):
     for r in reversed(rewards):
         R = r + gamma * R
         returns.insert(0, R)
-    s_t = torch.tensor(states, dtype=torch.float32, device=agent.device)
+    s_t = torch.stack([s.to(agent.device) if torch.is_tensor(s) else torch.tensor(s, dtype=torch.float32, device=agent.device) for s in states])
     a_t = torch.stack(actions).to(agent.device)
     with torch.no_grad():
         q_pred = agent.critic1(s_t, a_t).squeeze(1).cpu().numpy()


### PR DESCRIPTION
## Summary
- fix `rollout_episode` in `evaluate_bc_model.py` by stacking state tensors properly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68669f191ac88330a00088fadc464e30