### PR TITLE
Add baseline MNIST training

### DIFF
--- a/curriculum_env.py
+++ b/curriculum_env.py
@@ -205,6 +205,52 @@ class CurriculumEnv:
 
         return self.get_observation()
 
+    def reset_with_fractions(self, easy_frac: float, medium_frac: float):
+        """Reset the environment using the provided easy/medium fractions."""
+        self.easy_frac = easy_frac
+        self.medium_frac = medium_frac
+
+        # Update subset indices based on preset fractions
+        e_idx, m_idx, h_idx = self._generate_splits()
+        self.easy_subset.indices = e_idx
+        self.medium_subset.indices = m_idx
+        self.hard_subset.indices = h_idx
+
+        dl_args = dict(
+            batch_size=self.batch_size,
+            shuffle=True,
+            num_workers=4,
+            pin_memory=True,
+            persistent_workers=True,
+        )
+        self.easy_loader = DataLoader(self.easy_subset, **dl_args)
+        self.medium_loader = DataLoader(self.medium_subset, **dl_args)
+        self.hard_loader = DataLoader(self.hard_subset, **dl_args)
+        self.warmup_loader = DataLoader(
+            ConcatDataset([self.easy_subset, self.medium_subset, self.hard_subset]),
+            **dl_args,
+        )
+
+        self._init_model()
+        self.current_phase = 0
+        self.remaining_samples = self.train_samples_max
+
+        # Warm-up the new model on the fixed split
+        self.model.train()
+        opt = torch.optim.Adam(self.model.parameters(), lr=sum(self.lr_range) / 2)
+        criterion = nn.CrossEntropyLoss()
+        max_batches = max(1, int(0.25 * len(self.warmup_loader)))
+        for i, (x, y) in enumerate(self.warmup_loader):
+            if i >= max_batches:
+                break
+            x, y = x.to(self.device), y.to(self.device)
+            opt.zero_grad()
+            loss = criterion(self.model(x), y)
+            loss.backward()
+            opt.step()
+
+        return self.get_observation()
+
     def step(self, action):
         a = action if torch.is_tensor(action) else torch.tensor(action, dtype=torch.float32)
         lr, mix, frac = float(a[0]), a[1:4], float(a[4])

--- a/curriculum_env.py
+++ b/curriculum_env.py
@@ -149,13 +149,19 @@ class CurriculumEnv:
         avail = torch.tensor(self.remaining_samples/self.train_samples_max, device=self.device).unsqueeze(0)
         return torch.cat([obs, phase, avail], dim=0)
 
-    def reset(self):
-        # Sample fractions
-        easy = random.uniform(self.easy_lower, self.easy_upper)
-        max_med = min(easy, 1.0-easy-self.hard_min)
-        min_med = max(self.medium_lower, (1.0-easy)/2)
-        self.easy_frac = easy
-        self.medium_frac = (min_med+max_med)/2 if max_med<=min_med else random.uniform(min_med, max_med)
+    def reset(self, easy_frac: float | None = None, medium_frac: float | None = None):
+        """Reset the environment. Optionally specify dataset fractions."""
+        if easy_frac is None or medium_frac is None:
+            easy = random.uniform(self.easy_lower, self.easy_upper)
+            max_med = min(easy, 1.0 - easy - self.hard_min)
+            min_med = max(self.medium_lower, (1.0 - easy) / 2)
+            self.easy_frac = easy
+            self.medium_frac = (
+                (min_med + max_med) / 2 if max_med <= min_med else random.uniform(min_med, max_med)
+            )
+        else:
+            self.easy_frac = easy_frac
+            self.medium_frac = medium_frac
 
         # Update subset indices
         e_idx, m_idx, h_idx = self._generate_splits()
@@ -205,51 +211,6 @@ class CurriculumEnv:
 
         return self.get_observation()
 
-    def reset_with_fractions(self, easy_frac: float, medium_frac: float):
-        """Reset the environment using the provided easy/medium fractions."""
-        self.easy_frac = easy_frac
-        self.medium_frac = medium_frac
-
-        # Update subset indices based on preset fractions
-        e_idx, m_idx, h_idx = self._generate_splits()
-        self.easy_subset.indices = e_idx
-        self.medium_subset.indices = m_idx
-        self.hard_subset.indices = h_idx
-
-        dl_args = dict(
-            batch_size=self.batch_size,
-            shuffle=True,
-            num_workers=4,
-            pin_memory=True,
-            persistent_workers=True,
-        )
-        self.easy_loader = DataLoader(self.easy_subset, **dl_args)
-        self.medium_loader = DataLoader(self.medium_subset, **dl_args)
-        self.hard_loader = DataLoader(self.hard_subset, **dl_args)
-        self.warmup_loader = DataLoader(
-            ConcatDataset([self.easy_subset, self.medium_subset, self.hard_subset]),
-            **dl_args,
-        )
-
-        self._init_model()
-        self.current_phase = 0
-        self.remaining_samples = self.train_samples_max
-
-        # Warm-up the new model on the fixed split
-        self.model.train()
-        opt = torch.optim.Adam(self.model.parameters(), lr=sum(self.lr_range) / 2)
-        criterion = nn.CrossEntropyLoss()
-        max_batches = max(1, int(0.25 * len(self.warmup_loader)))
-        for i, (x, y) in enumerate(self.warmup_loader):
-            if i >= max_batches:
-                break
-            x, y = x.to(self.device), y.to(self.device)
-            opt.zero_grad()
-            loss = criterion(self.model(x), y)
-            loss.backward()
-            opt.step()
-
-        return self.get_observation()
 
     def step(self, action):
         a = action if torch.is_tensor(action) else torch.tensor(action, dtype=torch.float32)

--- a/evaluate_bc_model.py
+++ b/evaluate_bc_model.py
@@ -16,9 +16,9 @@ def load_config(path):
         return yaml.safe_load(f)
 
 
-def rollout_episode(agent, env, gamma):
+def rollout_episode(agent, env, gamma, reset_env=True):
     """Run one episode and return total reward and (Q, return) pairs."""
-    state = env.reset()
+    state = env.reset() if reset_env else env.get_observation()
     done = False
     states, actions, rewards = [], [], []
     while not done:
@@ -53,6 +53,13 @@ def evaluate_agent(agent, env, episodes=100, gamma=0.99):
     avg_reward = float(np.mean(rewards)) if rewards else 0.0
     mse = float(np.mean((np.array(preds) - np.array(targets)) ** 2)) if preds else 0.0
     return avg_reward, mse
+
+
+def evaluate_single_episode(agent, env, gamma=0.99):
+    r, pairs = rollout_episode(agent, env, gamma, reset_env=False)
+    preds, targets = zip(*pairs) if pairs else ([], [])
+    mse = float(np.mean((np.array(preds) - np.array(targets)) ** 2)) if preds else 0.0
+    return r, mse
 
 
 def train_standard_model(env, total_samples, lr):
@@ -121,12 +128,13 @@ def main():
 
     cfg = load_config(args.config)
     print(f"Loaded config from {args.config}")
-    env = CurriculumEnv(cfg)
-    print("Environment created")
-    obs_dim = len(env.reset())
+
+    # Temporary env to determine observation dimension
+    tmp_env = CurriculumEnv(cfg)
+    obs_dim = len(tmp_env.reset())
     action_dim = 5
 
-    # Evaluate behavior cloned model
+    # Initialize agents
     agent = DDPGAgent(obs_dim, action_dim, cfg)
     bc_dir = os.path.join("results", "behavior_cloning")
     actor_pth = os.path.join(bc_dir, "actor.pth")
@@ -140,31 +148,46 @@ def main():
     agent.actor.eval()
     agent.critic1.eval()
 
-    print(f"Evaluating behavior cloned model for {args.episodes} episodes...")
-    avg_r, mse = evaluate_agent(
-        agent, env, episodes=args.episodes, gamma=cfg["rl"].get("gamma", 0.99)
-    )
-    print(f"Behavior Cloned Model - Avg Reward: {avg_r:.3f}, Critic MSE: {mse:.3f}")
-
-    # Baseline random agent
     base_agent = DDPGAgent(obs_dim, action_dim, cfg)
     base_agent.actor.eval()
     base_agent.critic1.eval()
-    print(f"Evaluating random baseline for {args.episodes} episodes...")
-    avg_r_base, mse_base = evaluate_agent(
-        base_agent, env, episodes=args.episodes, gamma=cfg["rl"].get("gamma", 0.99)
-    )
-    print(f"Random Baseline - Avg Reward: {avg_r_base:.3f}, Critic MSE: {mse_base:.3f}")
 
-    # Standard training comparison
-    print("Training standard model with fixed batching...")
-    env_std = CurriculumEnv(cfg)
-    env_std.reset()
+    gamma = cfg["rl"].get("gamma", 0.99)
     lr_default = sum(cfg["curriculum"]["learning_rate_range"]) / 2
-    macro_acc = train_standard_model(
-        env_std, cfg["curriculum"]["train_samples_max"], lr_default
+
+    bc_rewards, bc_mses = [], []
+    base_rewards, base_mses = [], []
+    std_accs = []
+
+    for _ in trange(args.episodes, desc="Evaluation Episodes", leave=False):
+        proto_env = CurriculumEnv(cfg)
+        proto_env.reset()
+        easy, med = proto_env.easy_frac, proto_env.medium_frac
+
+        env_bc = CurriculumEnv(cfg)
+        env_bc.reset_with_fractions(easy, med)
+        r_bc, mse_bc = evaluate_single_episode(agent, env_bc, gamma)
+        bc_rewards.append(r_bc)
+        bc_mses.append(mse_bc)
+
+        env_base = CurriculumEnv(cfg)
+        env_base.reset_with_fractions(easy, med)
+        r_base, mse_base = evaluate_single_episode(base_agent, env_base, gamma)
+        base_rewards.append(r_base)
+        base_mses.append(mse_base)
+
+        env_std = CurriculumEnv(cfg)
+        env_std.reset_with_fractions(easy, med)
+        acc = train_standard_model(env_std, cfg["curriculum"]["train_samples_max"], lr_default)
+        std_accs.append(acc)
+
+    print(
+        f"Behavior Cloned Model - Avg Reward: {np.mean(bc_rewards):.3f}, Critic MSE: {np.mean(bc_mses):.3f}"
     )
-    print(f"Standard Training Macro Accuracy: {macro_acc:.2f}%")
+    print(
+        f"Random Baseline - Avg Reward: {np.mean(base_rewards):.3f}, Critic MSE: {np.mean(base_mses):.3f}"
+    )
+    print(f"Standard Training Macro Accuracy: {np.mean(std_accs):.2f}%")
 
 
 if __name__ == "__main__":

--- a/evaluate_bc_model.py
+++ b/evaluate_bc_model.py
@@ -6,6 +6,8 @@ import torch
 from tqdm import trange
 
 from curriculum_env import CurriculumEnv
+from curriculum_env import build_cnn_model, build_mlp_model
+from curriculum import evaluate_accuracy
 from rl_agent import DDPGAgent
 
 
@@ -53,6 +55,62 @@ def evaluate_agent(agent, env, episodes=100, gamma=0.99):
     return avg_reward, mse
 
 
+def train_standard_model(env, total_samples, lr):
+    """Train a model on MNIST without curriculum for a fixed number of samples."""
+    from torch.utils.data import ConcatDataset, WeightedRandomSampler, DataLoader
+    import torch.nn as nn
+
+    device = env.device
+    model_cfg = env.model_config
+    model_type = env.config.get("model_type", "cnn")
+    if model_type == "mlp":
+        model = build_mlp_model(model_cfg["hidden_layers"], model_cfg["activation"]).to(device)
+    else:
+        model = build_cnn_model(
+            model_cfg["n_convs"],
+            model_cfg["conv_ch"],
+            model_cfg["n_fcs"],
+            model_cfg["fc_units"],
+            model_cfg["activation"],
+            model_cfg["dropout"],
+        ).to(device)
+
+    dataset = ConcatDataset([
+        env.full_easy_ds,
+        env.full_medium_ds,
+        env.full_hard_ds,
+    ])
+    weights = [1 / 3] * len(env.full_easy_ds) + [1 / 3] * len(env.full_medium_ds) + [1 / 3] * len(env.full_hard_ds)
+    sampler = WeightedRandomSampler(weights, num_samples=total_samples, replacement=True)
+    loader = DataLoader(
+        dataset,
+        batch_size=env.batch_size,
+        sampler=sampler,
+        num_workers=4,
+        pin_memory=True,
+        persistent_workers=True,
+    )
+
+    criterion = nn.CrossEntropyLoss()
+    optimiser = torch.optim.Adam(model.parameters(), lr=lr)
+    model.train()
+    samples = 0
+    for imgs, labels in loader:
+        imgs, labels = imgs.to(device), labels.to(device)
+        optimiser.zero_grad()
+        loss = criterion(model(imgs), labels)
+        loss.backward()
+        optimiser.step()
+        samples += imgs.size(0)
+        if samples >= total_samples:
+            break
+
+    easy = evaluate_accuracy(model, env.easy_loader, device)
+    med = evaluate_accuracy(model, env.medium_loader, device)
+    hard = evaluate_accuracy(model, env.hard_loader, device)
+    return (easy + med + hard) / 3.0
+
+
 def main():
     p = argparse.ArgumentParser()
     p.add_argument("--config", "-c", default="config.yaml", help="Path to config.yaml")
@@ -97,6 +155,16 @@ def main():
         base_agent, env, episodes=args.episodes, gamma=cfg["rl"].get("gamma", 0.99)
     )
     print(f"Random Baseline - Avg Reward: {avg_r_base:.3f}, Critic MSE: {mse_base:.3f}")
+
+    # Standard training comparison
+    print("Training standard model with fixed batching...")
+    env_std = CurriculumEnv(cfg)
+    env_std.reset()
+    lr_default = sum(cfg["curriculum"]["learning_rate_range"]) / 2
+    macro_acc = train_standard_model(
+        env_std, cfg["curriculum"]["train_samples_max"], lr_default
+    )
+    print(f"Standard Training Macro Accuracy: {macro_acc:.2f}%")
 
 
 if __name__ == "__main__":

--- a/evaluate_bc_model.py
+++ b/evaluate_bc_model.py
@@ -165,19 +165,19 @@ def main():
         easy, med = proto_env.easy_frac, proto_env.medium_frac
 
         env_bc = CurriculumEnv(cfg)
-        env_bc.reset_with_fractions(easy, med)
+        env_bc.reset(easy, med)
         r_bc, mse_bc = evaluate_single_episode(agent, env_bc, gamma)
         bc_rewards.append(r_bc)
         bc_mses.append(mse_bc)
 
         env_base = CurriculumEnv(cfg)
-        env_base.reset_with_fractions(easy, med)
+        env_base.reset(easy, med)
         r_base, mse_base = evaluate_single_episode(base_agent, env_base, gamma)
         base_rewards.append(r_base)
         base_mses.append(mse_base)
 
         env_std = CurriculumEnv(cfg)
-        env_std.reset_with_fractions(easy, med)
+        env_std.reset(easy, med)
         acc = train_standard_model(env_std, cfg["curriculum"]["train_samples_max"], lr_default)
         std_accs.append(acc)
 


### PR DESCRIPTION
## Summary
- train a standard MNIST model for the same number of samples as curriculum training
- integrate baseline results in evaluation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68768510ec808330ba49066e2c038f39