### PR TITLE
Add progress logging

### DIFF
--- a/off_policy_train.py
+++ b/off_policy_train.py
@@ -250,6 +250,7 @@ def main():
         "next_states": next_states,
         "dones": dones,
     }
+    print(f"Loaded dataset from {dataset_path} with {len(states)} transitions")
 
     env = CurriculumEnv(config)
     obs_dim = len(env.reset())
@@ -260,7 +261,17 @@ def main():
     elite_data = select_top_percent(dataset, top_percent)
 
     elite_fraction = top_percent / 100.0
-    replay_buffer = build_augmented_replay_buffer(elite_data, dataset, config["rl"]["buffer_size"], elite_fraction, config["device"])
+    replay_buffer = build_augmented_replay_buffer(
+        elite_data,
+        dataset,
+        config["rl"]["buffer_size"],
+        elite_fraction,
+        config["device"],
+    )
+    print(
+        f"Replay buffer initialized with {len(replay_buffer)} transitions "
+        f"(capacity {config['rl']['buffer_size']})"
+    )
 
     probe_batch_size = 256
     perm = torch.randperm(len(states))
@@ -272,6 +283,7 @@ def main():
     checkpoint_interval = int(num_updates * 0.2)
     if checkpoint_interval == 0:
         checkpoint_interval = 1
+    print(f"Starting off-policy training for {num_updates} updates")
 
     # Lists for tracking metrics over training.
     actor_losses = []
@@ -305,12 +317,14 @@ def main():
             eval_rewards = []
             obs_eval = env.reset()
             done = False
-            while not done:
-                action_eval = agent.select_action(obs_eval, noise_enable=False)
-                eval_states.append(obs_eval)
-                eval_actions.append(action_eval)
-                obs_eval, reward, done = env.step(action_eval)
-                eval_rewards.append(reward)
+            with tqdm(total=env.max_phases, desc=f"Eval {update}", leave=False) as pbar:
+                while not done:
+                    action_eval = agent.select_action(obs_eval, noise_enable=False)
+                    eval_states.append(obs_eval)
+                    eval_actions.append(action_eval)
+                    obs_eval, reward, done = env.step(action_eval)
+                    eval_rewards.append(reward)
+                    pbar.update(1)
             total_reward = sum(eval_rewards)
             reward_progress.append(total_reward)
             eval_updates.append(update)
@@ -392,12 +406,14 @@ def main():
     eval_rewards = []
     obs_eval = env.reset()
     done = False
-    while not done:
-        action_eval = agent.select_action(obs_eval, noise_enable=False)
-        eval_states.append(obs_eval)
-        eval_actions.append(action_eval)
-        obs_eval, reward, done = env.step(action_eval)
-        eval_rewards.append(reward)
+    with tqdm(total=env.max_phases, desc="Final Eval", leave=False) as pbar:
+        while not done:
+            action_eval = agent.select_action(obs_eval, noise_enable=False)
+            eval_states.append(obs_eval)
+            eval_actions.append(action_eval)
+            obs_eval, reward, done = env.step(action_eval)
+            eval_rewards.append(reward)
+            pbar.update(1)
     total_reward = sum(eval_rewards)
     print(f"Final evaluation episode total reward: {total_reward}")
     

--- a/on_policy_train_parallel.py
+++ b/on_policy_train_parallel.py
@@ -139,7 +139,7 @@ def train_group(vec_model: ParallelMLP, env: CurriculumEnv, hyper_list: List[dic
     opt = torch.optim.Adam(vec_model.parameters(), lr=sum(hp["learning_rate"] for hp in hyper_list) / len(hyper_list))
     crit = nn.CrossEntropyLoss(reduction="none")
     vec_model.train()
-    for imgs, labels in loader:
+    for imgs, labels in tqdm(loader, desc="Group Train", leave=False):
         # Loader returns [batch, num_models, ...]; swap to [num_models, batch, ...]
         imgs = imgs.to(device).transpose(0, 1)
         labels = labels.to(device).transpose(0, 1)
@@ -153,7 +153,9 @@ def train_group(vec_model: ParallelMLP, env: CurriculumEnv, hyper_list: List[dic
     ea, _ = eval_loader_batched(vec_model, env.easy_loader, device, env.num_bins)
     ma, _ = eval_loader_batched(vec_model, env.medium_loader, device, env.num_bins)
     ha, _ = eval_loader_batched(vec_model, env.hard_loader, device, env.num_bins)
-    return ((ea + ma + ha) / 3.0).tolist()
+    accs = ((ea + ma + ha) / 3.0).tolist()
+    print(f"Group training complete — mean accuracy: {accs}")
+    return accs
 
 
 def main():
@@ -176,6 +178,10 @@ def main():
         d: ParallelMLP([model_cfgs[i] for i in idxs]).to(env.device)
         for d, idxs in depth_groups.items()
     }
+    print(
+        f"Initialized {num_students} student models across "
+        f"{len(depth_groups)} depth groups"
+    )
 
     if cfg["rl"].get("per_enabled", False):
         replay_buffer = PERBuffer(
@@ -239,6 +245,7 @@ def main():
             agent.update(replay_buffer, batch_size)
 
         if ep % max(1, int(num_episodes * 0.1)) == 0:
+            print(f"Completed episode {ep}/{num_episodes}")
             for d, idxs in depth_groups.items():
                 vec = group_models[d]
                 for li, gi in enumerate(idxs):
@@ -258,7 +265,10 @@ def main():
                             m.weight.data.copy_(w)
                             m.bias.data.copy_(b)
                             li2 += 1
+
                     torch.save(single.state_dict(), os.path.join(ckpt_dir, f"student_{gi}_ep{ep}.pt"))
+
+    print("Parallel on-policy training complete.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add printouts for dataset loading and replay buffer details in off_policy_train
- show progress while evaluating episodes
- report start of training updates
- enable progress bars for group training and add accuracy logs in on_policy_train_parallel
- print status updates during parallel on-policy loops

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687e6c7ea76483308ea17a2fa5226624