### PR TITLE
Fix PERBuffer epsilon bug

### DIFF
--- a/replay_buffer.py
+++ b/replay_buffer.py
@@ -70,9 +70,10 @@ class PERBuffer(ReplayBuffer):
     def __init__(self, capacity, device, alpha=0.6, beta=0.4, epsilon=1e-6, per_type="proportional"):
         super().__init__(capacity, device)
         self.priorities = torch.zeros(capacity, device=device)
-        self.alpha = alpha
-        self.beta = beta
-        self.epsilon = epsilon
+        # Cast hyperparameters to floats in case they are provided as strings
+        self.alpha = float(alpha)
+        self.beta = float(beta)
+        self.epsilon = float(epsilon)
         self.per_type = per_type
 
     def push(self, *args):


### PR DESCRIPTION
## Summary
- convert PERBuffer hyperparameters to floats to avoid string math errors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687ec23330788330b1c36a20cfffd861